### PR TITLE
Migrate from prefix commands to slash commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,17 +361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "command_attr"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcc89439e1bb4e19050a9586a767781a3060000d2f3296fd2a40597ad9421c5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +523,17 @@ checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1425,12 +1425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "levenshtein"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
-
-[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +1775,35 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poise"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1819d5a45e3590ef33754abce46432570c54a120798bdbf893112b4211fa09a6"
+dependencies = [
+ "async-trait",
+ "derivative",
+ "futures-util",
+ "parking_lot",
+ "poise_macros",
+ "regex",
+ "serenity",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "poise_macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fa2c123c961e78315cd3deac7663177f12be4460f5440dbf62a7ed37b1effea"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2466,12 +2489,10 @@ dependencies = [
  "bitflags 2.9.1",
  "bytes",
  "chrono",
- "command_attr",
  "dashmap 5.5.3",
  "flate2",
  "futures",
  "fxhash",
- "levenshtein",
  "mime_guess",
  "parking_lot",
  "percent-encoding",
@@ -2480,7 +2501,6 @@ dependencies = [
  "serde",
  "serde_cow",
  "serde_json",
- "static_assertions",
  "time",
  "tokio",
  "tokio-tungstenite",
@@ -2488,7 +2508,6 @@ dependencies = [
  "typemap_rev",
  "typesize",
  "url",
- "uwl",
 ]
 
 [[package]]
@@ -2587,12 +2606,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -3171,12 +3184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uwl"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bf03e0ca70d626ecc4ba6b0763b934b6f2976e8c744088bb3c1d646fbb1ad0"
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,8 +3422,8 @@ dependencies = [
  "dotenv",
  "itertools",
  "once_cell",
+ "poise",
  "serde",
- "serenity",
  "tokio",
  "warframe",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ dirs = "6.0.0"
 dotenv = "0.15.0"
 itertools = "0.14.0"
 once_cell = "1.21.3"
+poise = "0.6.1"
 serde = { version = "1.0.219", features = ["derive"] }
-serenity = "0.12.4"
 tokio = "1.46.1"
 warframe = "7.0.1"

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             cargo
+            cargo-expand
             clippy
             rustc
             rustfmt

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,40 @@
+use crate::handler::Handler;
+
+use anyhow::{Error, Result};
+use poise::command;
+
+type Context<'a> = poise::Context<'a, Handler, Error>;
+
+/// Show when baro will be here next, or his inventory if he's here
+#[command(slash_command, guild_cooldown = 360)]
+pub async fn baro(ctx: Context<'_>) -> Result<()> {
+    let handler = ctx.data();
+    handler.notify_baro().await;
+    ctx.say("Update sent to news channel.").await?;
+    Ok(())
+}
+
+/// Show unseen news
+#[command(slash_command)]
+pub async fn news(ctx: Context<'_>) -> Result<()> {
+    let handler = ctx.data();
+    let something_sent = handler.notify_news().await;
+    let message = if something_sent {
+        "Update sent to news channel."
+    } else {
+        "No news to show."
+    };
+    ctx.say(message).await?;
+    Ok(())
+}
+
+/// Print a help message
+#[command(slash_command)]
+pub async fn help(ctx: Context<'_>) -> Result<()> {
+    let help_message = "Available Commands:\n\
+                        - !baro: Show when baro will be here next, or his inventory if he's here\n\
+                        - !news: Show unseen news\n\
+                        - !help: Print this message";
+    ctx.say(help_message).await?;
+    Ok(())
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -33,8 +33,8 @@ impl Handler {
         *self.connection.lock().await = Some(connection);
     }
 
-    /// Send a message to the news channel with currently unseen news items.
-    pub async fn notify_news(&self) -> bool {
+    /// Returns a list of news items as messages. Empty if no news items were found.
+    pub async fn news_messages(&self) -> Vec<String> {
         // Fetch the recent news, and map it into the correct type
         let news: Vec<News> = match self.worldstate.fetch::<queryable::News>().await {
             Ok(response) => response
@@ -49,11 +49,11 @@ impl Handler {
 
             Err(e) => {
                 warning!(context = "fetching news", "{e}");
-                return true;
+                return vec![];
             }
         };
 
-        // Get a handle for the cache and the Discord connection.
+        // Get a handle for the cache.
         let mut cache = self.news_cache.lock().await;
 
         // Get the subset of news listings that have not been seen thus far.
@@ -61,27 +61,34 @@ impl Handler {
 
         // If there's nothing to report, we log it and move on.
         if news.is_empty() {
-            info!("no unseen news");
-            return false;
+            return vec![];
         }
 
-        // Send a message for each.
-        let messages = news
-            .into_iter()
+        // Update the cache.
+        if let Err(e) = cache.dump() {
+            warning!(context = "dumping cache", "{e}");
+        }
+
+        // If there are news items, map them into messages for consumption by other functions.
+        news.into_iter()
             .filter_map(|news_item| {
                 news_item
                     .as_message()
                     .inspect_err(|e| warning!(context = "formatting news", "{e}"))
                     .ok()
             })
-            .collect::<Vec<_>>();
-        self.say_multiple(&messages).await;
+            .collect::<Vec<_>>()
+    }
 
-        // Update the cache.
-        if let Err(e) = cache.dump() {
-            warning!(context = "dumping cache", "{e}");
+    /// Send messages to the news channel with currently unseen news items.
+    pub async fn notify_news(&self) {
+        let messages = self.news_messages().await;
+        if messages.is_empty() {
+            info!("no unseen news");
+            return;
         }
-        true
+
+        self.say_multiple(&messages).await;
     }
 
     /// Returns `true` if Baro Ki'Teer is active.
@@ -97,20 +104,26 @@ impl Handler {
         trader.active()
     }
 
-    /// Send a message or messages to the news channel with information about Baro Ki'Teer's
-    /// current or next visit.
-    pub async fn notify_baro(&self) {
+    /// Utility function that fetches the active trader information and passes it along to the
+    /// formatter function.
+    pub async fn baro_messages(&self) -> Vec<String> {
         // Fetch the most recent information about Baro Ki'Teer.
         let trader = match self.worldstate.fetch::<queryable::VoidTrader>().await {
             Ok(trader) => trader,
             Err(e) => {
                 warning!(context = "fetching trader", "{e}");
-                return;
+                return vec![];
             }
         };
 
-        // Construct the messages, and prepare the connecion.
-        let messages = calculate_baro_string(&trader).await;
+        // Construct the messages
+        calculate_baro_string(&trader).await
+    }
+
+    /// Send a message or messages to the news channel with information about Baro Ki'Teer's
+    /// current or next visit.
+    pub async fn notify_baro(&self) {
+        let messages = self.baro_messages().await;
 
         self.say_multiple(&messages).await;
     }

--- a/src/item_display.rs
+++ b/src/item_display.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use serenity::all::MessageBuilder;
+use poise::serenity_prelude::MessageBuilder;
 use warframe::worldstate::items::Item;
 use warframe::worldstate::queryable::VoidTrader;
 use warframe::worldstate::{TimedEvent, VoidTraderInventoryItem};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod blacklist;
 mod cache;
 pub mod cli;
+pub mod commands;
 pub mod handler;
 mod item_display;
 pub mod logging;
@@ -8,38 +9,9 @@ mod news_wrapper;
 pub mod periodic;
 
 pub use blacklist::BLACKLIST;
-#[allow(unused)]
 pub use news_wrapper::*;
 
-use cli::Cli;
-
-use std::env;
-use std::sync::Arc;
-
-use anyhow::{Context, Result};
-
-/// Initialise the Discord bot client.
-pub async fn init_bot(args: &Cli, handler: Arc<handler::Handler>) -> Result<serenity::Client> {
-    use serenity::Client;
-    use serenity::prelude::*;
-    let intents = GatewayIntents::default()
-        | GatewayIntents::GUILD_MESSAGES
-        | GatewayIntents::MESSAGE_CONTENT;
-
-    let client = Client::builder(&args.api_token, intents)
-        .event_handler_arc(handler)
-        .await?;
-
-    Ok(client)
-}
-
-/// Load the Discord Channel ID from an environment variable.
-pub fn load_channel_id() -> Result<u64> {
-    const ERR_MESG: &str = "A valid Discord Channel ID is required to run wf-bot.";
-    let channel_id = env::var("WF_CHANNELID").context(ERR_MESG)?;
-
-    Ok(channel_id.parse()?)
-}
+use anyhow::Result;
 
 /// Format the date style given by the warframe API.
 pub fn fmt_api_date(date: &chrono::DateTime<chrono::Utc>) -> Result<String> {


### PR DESCRIPTION
This PR fully remove the old prefix commands and replaces them with slash commands. This brings a few benefits:

- Commands can now be put on cooldown (this is Andrew's fault)
- Commands can be auto-completed on the user side
- Interface is now more professional

In addition the PR brings some refactors to the `Handler` struct that separates making message contents and sending them.