### PR TITLE
Add a way to display the weekly reset

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1,0 +1,54 @@
+use chrono::{DateTime, TimeZone, Utc};
+use once_cell::sync::Lazy;
+
+// Most recent time of first rotation as of writing.
+#[rustfmt::skip]
+const EPOCH: Lazy<DateTime<Utc>> =
+    Lazy::new(|| Utc.with_ymd_and_hms(2025, 6, 9, 0, 0, 0).unwrap());
+
+// Most recent time of first rotation for the Steel Path as of writing.
+const SP_EPOCH: Lazy<DateTime<Utc>> =
+    Lazy::new(|| Utc.with_ymd_and_hms(2025, 7, 21, 0, 0, 0).unwrap());
+
+#[rustfmt::skip]
+const REWARDS: [[&str; 3]; 11] = [
+    ["Excalibur", "Trinity", "Ember"   ],
+    ["Loki",      "Mag",     "Rhino"   ],
+    ["Ash",       "Frost",   "Nyx"     ],
+    ["Saryn",     "Vauban",  "Nova"    ],
+    ["Nekros",    "Valkyr",  "Oberon"  ],
+    ["Hydroid",   "Mirage",  "Limbo"   ],
+    ["Mesa",      "Chroma",  "Atlas"   ],
+    ["Ivara",     "Inaros",  "Titania" ],
+    ["Nidus",     "Octavia", "Harrow"  ],
+    ["Gara",      "Khora",   "Revenant"],
+    ["Garuda",    "Baruuk",  "Hildryn" ],
+];
+
+#[rustfmt::skip]
+const SP_REWARDS: [[&str; 5]; 8] = [
+    ["Braton",      "Lato",          "Skana",      "Paris",     "Kunai"         ],
+    ["Boar",        "Gammacor",      "Angstrum",   "Gorgon",    "Anku"          ],
+    ["Bo",          "Latron",        "Furis",      "Furax",     "Strun"         ],
+    ["Lex",         "Magistar",      "Boltor",     "Bronco",    "Ceramic Dagger"],
+    ["Torid",       "Dual Toxocyst", "Dual Ichor", "Miter",     "Atomos"        ],
+    ["Ack & Brunt", "Soma",          "Vasto",      "Nami Solo", "Burston"       ],
+    ["Zylok",       "Sibear",        "Dread",      "Despair",   "Hate"          ],
+    ["Dera",        "Sybaris",       "Cestra",     "Sicarus",   "Okina"         ],
+];
+
+/// Get the Steel Path offerings from the Circuit.
+pub fn sp_circuit() -> [&'static str; 5] {
+    let now = Utc::now();
+    let week = (now - *SP_EPOCH).num_weeks() % 8;
+
+    SP_REWARDS[week as usize]
+}
+
+/// Get the offerings from the Circuit.
+pub fn circuit() -> [&'static str; 3] {
+    let now = Utc::now();
+    let week = (now - *EPOCH).num_weeks() % 11;
+
+    REWARDS[week as usize]
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,7 +13,7 @@ pub async fn baro(ctx: Context<'_>) -> Result<()> {
     let messages = handler.baro_messages().await;
 
     if messages.is_empty() {
-        ctx.say("Internal error, try again soon").await?;
+        ctx.say("Internal error, try again soon.").await?;
     }
     for msg in messages.into_iter() {
         if let Err(e) = ctx.say(msg).await {
@@ -42,13 +42,30 @@ pub async fn news(ctx: Context<'_>) -> Result<()> {
     Ok(())
 }
 
+/// Show what's in The Circuit, and what Archon Shard is available from this week's Archon Hunt.
+#[command(slash_command, guild_cooldown = 360)]
+pub async fn weekly(ctx: Context<'_>) -> Result<()> {
+    let handler = ctx.data();
+    let message = handler
+        .weekly_messages()
+        .await
+        .unwrap_or("Internal error, try again soon.".into());
+
+    if let Err(e) = ctx.say(&message).await {
+        warning!(context = "sending message", "{e}");
+    }
+
+    Ok(())
+}
+
 /// Print a help message
 #[command(slash_command)]
 pub async fn help(ctx: Context<'_>) -> Result<()> {
     let help_message = "Available Commands:\n\
-                        - `/baro`: Show when baro will be here next, or his inventory if he's here\n\
-                        - `/news`: Show unseen news\n\
-                        - `/help`: Print this message";
+                        - `/baro`  : Show when baro will be here next, or his inventory if he's here\n\
+                        - `/news`  : Show unseen news\n\
+                        - `/help`  : Print this message\n\
+                        - `/weekly`: Show what's in The Circuit and what Archon Hunt is available";
     ctx.say(help_message).await?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod blacklist;
 mod cache;
+mod circuit;
 pub mod cli;
 pub mod commands;
 pub mod handler;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ async fn main() -> anyhow::Result<()> {
     let handler = Arc::new(handler::Handler::new(args.channel_id.into()));
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
-            commands: vec![baro(), news(), help()],
+            commands: vec![baro(), news(), weekly(), help()],
             ..Default::default()
         })
         .setup(move |ctx, _ready, framework| {

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -42,6 +42,24 @@ pub async fn start_tasks(handler: Arc<Handler>) {
         },
     )
     .await;
+
+    // Send an update about Weekly offerings every Monday at 0:00 UTC.
+    let handler_clone = handler.clone();
+    task(
+        |now| {
+            let now_utc = now.with_timezone(&chrono::Utc);
+            now_utc.weekday() == chrono::Weekday::Mon
+                && now_utc.hour() == 0
+                && now_utc.minute() == 0
+        },
+        move || {
+            let handler = handler_clone.clone();
+            async move {
+                handler.notify_weekly().await;
+            }
+        },
+    )
+    .await;
 }
 
 /// Checks every minute whether a task should be run if a time-based condition is met.


### PR DESCRIPTION
This adds a command and periodic task, `weekly`, that shows the current offerings in both versions of The Circuit, as well as the currently available Archon Shard from the Archon Hunt.